### PR TITLE
Refactor ranking for ease of showing the modal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules/
+*.json
+

--- a/client/Main.css
+++ b/client/Main.css
@@ -77,6 +77,10 @@ tr:nth-of-type(even){
 	width: 25%;
 }
 
+.ranking .player {
+	line-height: 4rem;
+}
+
 .statistics-title {
 	text-align: center;
 }

--- a/client/Main.css
+++ b/client/Main.css
@@ -76,3 +76,7 @@ tr:nth-of-type(even){
 .ranking .players {
 	width: 25%;
 }
+
+.statistics-title {
+	text-align: center;
+}

--- a/client/Main.js
+++ b/client/Main.js
@@ -1,1 +1,1 @@
-import '../imports/ui/Body.js';
+import '../imports/ui/Body';

--- a/imports/api/Constants.js
+++ b/imports/api/Constants.js
@@ -1,5 +1,5 @@
 // A class/namespace of commonly used Constants
-export const Constants = {
+const Constants = {
 	// Title
 	MAHJONG_CLUB_LEAGUE: "Mahjong Club League",
 
@@ -25,8 +25,8 @@ export const Constants = {
 	// Score adjustment for Hong Kong ending scores
 	// Calculated as analogous to Japanese system
 	HKG_SCORE_ADJUSTMENT: [
-		 100,
-		 50,
+		100,
+		50,
 		-50,
 		-100
 	],
@@ -38,8 +38,8 @@ export const Constants = {
 	// 3rd = 3rd - 30,000 + 0 = -5,000
 	// 4th = 4th - 30,000 - 10,000 = -15,000
 	JPN_SCORE_ADJUSTMENT: [
-		 15000,
-		 5000,
+		15000,
+		5000,
 		-5000,
 		-15000
 	],
@@ -72,4 +72,17 @@ export const Constants = {
 	MISTAKE: "mistake"
 };
 
-Object.keys(Constants).forEach((k) => { Template.registerHelper(k, () => Constants[k] )});
+export default Constants;
+
+function registerConstants(object, prefix) {
+	for (let key in object) {
+		let value = object[key];
+		if (value instanceof Object && !Array.isArray(value)) {
+			registerConstants(value, prefix + key + ".");
+		} else {
+			Template.registerHelper(prefix + key, () => value);
+		}
+	}
+}
+
+registerConstants(Constants, "");

--- a/imports/api/EloCalculator.js
+++ b/imports/api/EloCalculator.js
@@ -1,4 +1,5 @@
 import Players from './Players';
+import Constants from './Constants';
 import GameTypeUtils from './utils/GameTypeUtils';
 
 export class EloCalculator {
@@ -136,6 +137,16 @@ export class EloCalculator {
 
 	// Return a player's ELO
 	getPlayerElo (player) {
-		return Number(GameTypeUtils.getPlayer(this.gameType, player).elo);
+		let criteria = {}
+		switch (this.gameType) {
+		case Constants.GAME_TYPE.HONG_KONG:
+			criteria["hongKongLeagueName"] = player;
+			break;
+		case Constants.GAME_TYPE.JAPANESE:
+			criteria["japaneseLeagueName"] = player;
+			break;
+		}
+
+		return Number(GameTypeUtils.getPlayer(this.gameType, criteria).elo);
 	}
 };

--- a/imports/api/EloCalculator.js
+++ b/imports/api/EloCalculator.js
@@ -2,7 +2,7 @@ import Players from './Players';
 import Constants from './Constants';
 import GameTypeUtils from './utils/GameTypeUtils';
 
-export class EloCalculator {
+export default class EloCalculator {
 	constructor (n, exp, placingAdjustments, game, gameType) {
 		this.n = n;
 		this.exp = exp;

--- a/imports/api/EloCalculator.js
+++ b/imports/api/EloCalculator.js
@@ -1,6 +1,5 @@
-import { Players } from './Players.js';
-
-import { Constants } from './Constants.js';
+import Players from './Players';
+import GameTypeUtils from './utils/GameTypeUtils';
 
 export class EloCalculator {
 	constructor (n, exp, placingAdjustments, game, gameType) {
@@ -137,11 +136,6 @@ export class EloCalculator {
 
 	// Return a player's ELO
 	getPlayerElo (player) {
-		switch (this.gameType) {
-		case Constants.GAME_TYPE.HONG_KONG:
-			return Number(Players.findOne({hongKongLeagueName: player}).hongKongElo);
-		case Constants.GAME_TYPE.JAPANESE:
-			return Number(Players.findOne({japaneseLeagueName: player}).japaneseElo);
-		}
+		return Number(GameTypeUtils.getPlayer(this.gameType, player).elo);
 	}
 };

--- a/imports/api/Players.js
+++ b/imports/api/Players.js
@@ -3,4 +3,4 @@ import { Mongo } from 'meteor/mongo';
 //Until some actually halfway programming happens players 
 //must be created and edited through the actual database
 // >>This might not be a bad thing
-export const Players = new Mongo.Collection('players');
+export default new Mongo.Collection('players');

--- a/imports/api/utils/GameTypeUtils.js
+++ b/imports/api/utils/GameTypeUtils.js
@@ -2,84 +2,84 @@ import Constants from '../Constants';
 import Players from '../Players';
 
 export default {
-    formatName(format) {
-        switch (format) {
-        case Constants.GAME_TYPE.JAPANESE:
-            return "Japanese";
-        case Constants.GAME_TYPE.HONG_KONG:
-            return "Hong Kong";
-        default:
-            logInvalidFormat(format);
-            return "Unknown";
-        }
-    },
+	formatName(format) {
+		switch (format) {
+		case Constants.GAME_TYPE.JAPANESE:
+			return "Japanese";
+		case Constants.GAME_TYPE.HONG_KONG:
+			return "Hong Kong";
+		default:
+			logInvalidFormat(format);
+			return "Unknown";
+		}
+	},
 
-    getPlayer(format, criteria) {
-        return standardizePlayerStatistics(format, Players.findOne(criteria));
-    },
+	getPlayer(format, criteria) {
+		return standardizePlayerStatistics(format, Players.findOne(criteria));
+	},
 
-    getPlayers(format, sort) {
-        let hasPlayedGames = {};
-        switch (format) {
-        case Constants.GAME_TYPE.JAPANESE:
-            hasPlayedGames["japaneseGamesPlayed"] = { $gt: 0 };
-            break;
-        case Constants.GAME_TYPE.HONG_KONG:
-            hasPlayedGames["hongKongGamesPlayed"] = { $gt: 0 };
-            break;
-        default:
-            logInvalidFormat(format);
-        }
+	getPlayers(format, sort) {
+		let hasPlayedGames = {};
+		switch (format) {
+		case Constants.GAME_TYPE.JAPANESE:
+			hasPlayedGames["japaneseGamesPlayed"] = { $gt: 0 };
+			break;
+		case Constants.GAME_TYPE.HONG_KONG:
+			hasPlayedGames["hongKongGamesPlayed"] = { $gt: 0 };
+			break;
+		default:
+			logInvalidFormat(format);
+		}
 
-        return Players.find(hasPlayedGames, { sort }).map((player) => standardizePlayerStatistics(format, player));
-    }
+		return Players.find(hasPlayedGames, { sort }).map((player) => standardizePlayerStatistics(format, player));
+	}
 }
 
 function standardizePlayerStatistics(format, player) {
-    let formatPlayer = {};
-    switch (format) {
-    case Constants.GAME_TYPE.JAPANESE:
-        formatPlayer["leagueName"] = player["japaneseLeagueName"];
-        formatPlayer["elo"] = player["japaneseElo"];
-        formatPlayer["gamesPlayed"] = player["japaneseGamesPlayed"];
-        formatPlayer["handsWin"] = player["japaneseHandsWin"];
-        formatPlayer["handsLose"] = player["japaneseHandsLose"];
-        formatPlayer["handsTotal"] = player["japaneseHandsTotal"];
-        formatPlayer["winPointsTotal"] = player["japaneseWinPointsTotal"];
-        formatPlayer["winDoraTotal"] = player["japaneseWinDoraTotal"];
-        formatPlayer["riichiTotal"] = player["japaneseRiichiTotal"];
-        formatPlayer["winRiichiTotal"] = player["japaneseWinRiichiTotal"];
-        formatPlayer["chomboTotal"] = player["japaneseChomboTotal"];
-        formatPlayer["bankruptTotal"] = player["japaneseBankruptTotal"];
-        formatPlayer["firstPlaceSum"] = player["japaneseFirstPlaceSum"];
-        formatPlayer["secondPlaceSum"] = player["japaneseSecondPlaceSum"];
-        formatPlayer["thirdPlaceSum"] = player["japaneseThirdPlaceSum"];
-        formatPlayer["fourthPlaceSum"] = player["japaneseFourthPlaceSum"];
-        break;
+	let formatPlayer = {};
+	switch (format) {
+	case Constants.GAME_TYPE.JAPANESE:
+		formatPlayer["leagueName"] = player["japaneseLeagueName"];
+		formatPlayer["elo"] = player["japaneseElo"];
+		formatPlayer["gamesPlayed"] = player["japaneseGamesPlayed"];
+		formatPlayer["handsWin"] = player["japaneseHandsWin"];
+		formatPlayer["handsLose"] = player["japaneseHandsLose"];
+		formatPlayer["handsTotal"] = player["japaneseHandsTotal"];
+		formatPlayer["winPointsTotal"] = player["japaneseWinPointsTotal"];
+		formatPlayer["winDoraTotal"] = player["japaneseWinDoraTotal"];
+		formatPlayer["riichiTotal"] = player["japaneseRiichiTotal"];
+		formatPlayer["winRiichiTotal"] = player["japaneseWinRiichiTotal"];
+		formatPlayer["chomboTotal"] = player["japaneseChomboTotal"];
+		formatPlayer["bankruptTotal"] = player["japaneseBankruptTotal"];
+		formatPlayer["firstPlaceSum"] = player["japaneseFirstPlaceSum"];
+		formatPlayer["secondPlaceSum"] = player["japaneseSecondPlaceSum"];
+		formatPlayer["thirdPlaceSum"] = player["japaneseThirdPlaceSum"];
+		formatPlayer["fourthPlaceSum"] = player["japaneseFourthPlaceSum"];
+		break;
 
-    case Constants.GAME_TYPE.HONG_KONG:
-        formatPlayer["leagueName"] = player["hongKongLeagueName"];
-        formatPlayer["elo"] = player["hongKongElo"];
-        formatPlayer["gamesPlayed"] = player["hongKongGamesPlayed"];
-        formatPlayer["handsWin"] = player["hongKongHandsWin"];
-        formatPlayer["handsLose"] = player["hongKongHandsLose"];
-        formatPlayer["handsTotal"] = player["hongKongHandsTotal"];
-        formatPlayer["winPointsTotal"] = player["hongKongWinPointsTotal"];
-        formatPlayer["chomboTotal"] = player["hongKongChomboTotal"];
-        formatPlayer["bankruptTotal"] = player["hongKongBankruptTotal"];
-        formatPlayer["firstPlaceSum"] = player["hongKongFirstPlaceSum"];
-        formatPlayer["secondPlaceSum"] = player["hongKongSecondPlaceSum"];
-        formatPlayer["thirdPlaceSum"] = player["hongKongThirdPlaceSum"];
-        formatPlayer["fourthPlaceSum"] = player["hongKongFourthPlaceSum"];
-        break;
+	case Constants.GAME_TYPE.HONG_KONG:
+		formatPlayer["leagueName"] = player["hongKongLeagueName"];
+		formatPlayer["elo"] = player["hongKongElo"];
+		formatPlayer["gamesPlayed"] = player["hongKongGamesPlayed"];
+		formatPlayer["handsWin"] = player["hongKongHandsWin"];
+		formatPlayer["handsLose"] = player["hongKongHandsLose"];
+		formatPlayer["handsTotal"] = player["hongKongHandsTotal"];
+		formatPlayer["winPointsTotal"] = player["hongKongWinPointsTotal"];
+		formatPlayer["chomboTotal"] = player["hongKongChomboTotal"];
+		formatPlayer["bankruptTotal"] = player["hongKongBankruptTotal"];
+		formatPlayer["firstPlaceSum"] = player["hongKongFirstPlaceSum"];
+		formatPlayer["secondPlaceSum"] = player["hongKongSecondPlaceSum"];
+		formatPlayer["thirdPlaceSum"] = player["hongKongThirdPlaceSum"];
+		formatPlayer["fourthPlaceSum"] = player["hongKongFourthPlaceSum"];
+		break;
 
-    default:
-        logInvalidFormat(format);
-        formatPlayer = player;
-    }
+	default:
+		logInvalidFormat(format);
+		formatPlayer = player;
+	}
 
-    formatPlayer["id"] = player["_id"];
-    return formatPlayer;
+	formatPlayer["id"] = player["_id"];
+	return formatPlayer;
 }
 
 function logInvalidFormat(format) { console.log("Format '" + format + "' is invalid") }

--- a/imports/api/utils/GameTypeUtils.js
+++ b/imports/api/utils/GameTypeUtils.js
@@ -1,0 +1,87 @@
+import Constants from '../Constants';
+import Players from '../Players';
+
+export default {
+    formatName(format) {
+        switch (format) {
+        case Constants.GAME_TYPE.JAPANESE:
+            return "Japanese";
+        case Constants.GAME_TYPE.HONG_KONG:
+            return "Hong Kong";
+        default:
+            err(format);
+            return "Unknown";
+        }
+    },
+
+    getPlayer(format, criteria) {
+        return standardizePlayerStatistics(format, Players.findOne(criteria));
+    },
+
+    getPlayers(format, sort) {
+        let hasPlayedGames = {};
+        switch (format) {
+        case Constants.GAME_TYPE.JAPANESE:
+            hasPlayedGames["japaneseGamesPlayed"] = { $gt: 0 };
+            break;
+        case Constants.GAME_TYPE.HONG_KONG:
+            hasPlayedGames["hongKongGamesPlayed"] = { $gt: 0 };
+            break;
+        default:
+            err(format);
+        }
+
+        return Players.find(hasPlayedGames, { sort }).map((player) => standardizePlayerStatistics(format, player));
+    }
+}
+
+function standardizePlayerStatistics(format, player) {
+    let formatPlayer = {};
+    switch (format) {
+    case Constants.GAME_TYPE.JAPANESE:
+        formatPlayer["leagueName"] = player["japaneseLeagueName"];
+        formatPlayer["elo"] = player["japaneseElo"];
+        formatPlayer["gamesPlayed"] = player["japaneseGamesPlayed"];
+        formatPlayer["positionSum"] = player["japanesePositionSum"];
+        formatPlayer["handsWin"] = player["japaneseHandsWin"];
+        formatPlayer["handsLose"] = player["japaneseHandsLose"];
+        formatPlayer["handsTotal"] = player["japaneseHandsTotal"];
+        formatPlayer["winPointsTotal"] = player["japaneseWinPointsTotal"];
+        formatPlayer["winDoraTotal"] = player["japaneseWinDoraTotal"];
+        formatPlayer["riichiTotal"] = player["japaneseRiichiTotal"];
+        formatPlayer["winRiichiTotal"] = player["japaneseWinRiichiTotal"];
+        formatPlayer["chomboTotal"] = player["japaneseChomboTotal"];
+        formatPlayer["bankruptTotal"] = player["japaneseBankruptTotal"];
+        formatPlayer["firstPlaceSum"] = player["japaneseFirstPlaceSum"];
+        formatPlayer["secondPlaceSum"] = player["japaneseSecondPlaceSum"];
+        formatPlayer["thirdPlaceSum"] = player["japaneseThirdPlaceSum"];
+        formatPlayer["fourthPlaceSum"] = player["japaneseFourthPlaceSum"];
+        break;
+
+    case Constants.GAME_TYPE.HONG_KONG:
+        formatPlayer["leagueName"] = player["hongKongLeagueName"];
+        formatPlayer["elo"] = player["hongKongElo"];
+        formatPlayer["gamesPlayed"] = player["hongKongGamesPlayed"];
+        formatPlayer["positionSum"] = player["hongKongPositionSum"];
+        formatPlayer["handsWin"] = player["hongKongHandsWin"];
+        formatPlayer["handsLose"] = player["hongKongHandsLose"];
+        formatPlayer["handsTotal"] = player["hongKongHandsTotal"];
+        formatPlayer["winPointsTotal"] = player["hongKongWinPointsTotal"];
+        formatPlayer["chomboTotal"] = player["hongKongChomboTotal"];
+        formatPlayer["bankruptTotal"] = player["hongKongBankruptTotal"];
+        formatPlayer["firstPlaceSum"] = player["hongKongFirstPlaceSum"];
+        formatPlayer["secondPlaceSum"] = player["hongKongSecondPlaceSum"];
+        formatPlayer["thirdPlaceSum"] = player["hongKongThirdPlaceSum"];
+        formatPlayer["fourthPlaceSum"] = player["hongKongFourthPlaceSum"];
+        break;
+
+    default:
+        err(format);
+        formatPlayer = player;
+    }
+
+    formatPlayer["id"] = player["_id"];
+    return formatPlayer;
+}
+
+function err(format) { console.log("Format '" + format + "' is invalid") }

--- a/imports/api/utils/GameTypeUtils.js
+++ b/imports/api/utils/GameTypeUtils.js
@@ -9,7 +9,7 @@ export default {
         case Constants.GAME_TYPE.HONG_KONG:
             return "Hong Kong";
         default:
-            err(format);
+            logInvalidFormat(format);
             return "Unknown";
         }
     },
@@ -28,7 +28,7 @@ export default {
             hasPlayedGames["hongKongGamesPlayed"] = { $gt: 0 };
             break;
         default:
-            err(format);
+            logInvalidFormat(format);
         }
 
         return Players.find(hasPlayedGames, { sort }).map((player) => standardizePlayerStatistics(format, player));
@@ -74,7 +74,7 @@ function standardizePlayerStatistics(format, player) {
         break;
 
     default:
-        err(format);
+        logInvalidFormat(format);
         formatPlayer = player;
     }
 
@@ -82,4 +82,4 @@ function standardizePlayerStatistics(format, player) {
     return formatPlayer;
 }
 
-function err(format) { console.log("Format '" + format + "' is invalid") }
+function logInvalidFormat(format) { console.log("Format '" + format + "' is invalid") }

--- a/imports/api/utils/GameTypeUtils.js
+++ b/imports/api/utils/GameTypeUtils.js
@@ -42,7 +42,6 @@ function standardizePlayerStatistics(format, player) {
         formatPlayer["leagueName"] = player["japaneseLeagueName"];
         formatPlayer["elo"] = player["japaneseElo"];
         formatPlayer["gamesPlayed"] = player["japaneseGamesPlayed"];
-        formatPlayer["positionSum"] = player["japanesePositionSum"];
         formatPlayer["handsWin"] = player["japaneseHandsWin"];
         formatPlayer["handsLose"] = player["japaneseHandsLose"];
         formatPlayer["handsTotal"] = player["japaneseHandsTotal"];
@@ -62,7 +61,6 @@ function standardizePlayerStatistics(format, player) {
         formatPlayer["leagueName"] = player["hongKongLeagueName"];
         formatPlayer["elo"] = player["hongKongElo"];
         formatPlayer["gamesPlayed"] = player["hongKongGamesPlayed"];
-        formatPlayer["positionSum"] = player["hongKongPositionSum"];
         formatPlayer["handsWin"] = player["hongKongHandsWin"];
         formatPlayer["handsLose"] = player["hongKongHandsLose"];
         formatPlayer["handsTotal"] = player["hongKongHandsTotal"];

--- a/imports/api/utils/NewGameUtils.js
+++ b/imports/api/utils/NewGameUtils.js
@@ -1,6 +1,6 @@
-import { Constants } from '../api/Constants.js';
+import Constants from '../Constants';
 
-export var NewGameUtils = {
+export default {
 
 	resetGameValues(defaultScore) {
 		Session.set("current_east", Constants.DEFAULT_EAST);

--- a/imports/ui/Body.js
+++ b/imports/ui/Body.js
@@ -1,5 +1,4 @@
 import { Template } from 'meteor/templating';
 
 import './Body.html';
-
-import './Index.js';
+import './Index';

--- a/imports/ui/HongKongNewGame.js
+++ b/imports/ui/HongKongNewGame.js
@@ -1,10 +1,10 @@
 //Databases
-import { Players } from '../api/Players.js';
-import { HongKongHands } from '../api/GameDatabases.js';
+import Players from '../api/Players';
+import { HongKongHands } from '../api/GameDatabases';
 
-import { Constants } from '../api/Constants.js';
-import { EloCalculator } from '../api/EloCalculator.js';
-import { NewGameUtils } from '../api/NewGameUtils.js';
+import Constants from '../api/Constants';
+import { EloCalculator } from '../api/EloCalculator';
+import NewGameUtils from '../api/utils/NewGameUtils';
 
 import './HongKongNewGame.html';
 

--- a/imports/ui/HongKongNewGame.js
+++ b/imports/ui/HongKongNewGame.js
@@ -3,7 +3,7 @@ import Players from '../api/Players';
 import { HongKongHands } from '../api/GameDatabases';
 
 import Constants from '../api/Constants';
-import { EloCalculator } from '../api/EloCalculator';
+import EloCalculator from '../api/EloCalculator';
 import NewGameUtils from '../api/utils/NewGameUtils';
 
 import './HongKongNewGame.html';

--- a/imports/ui/Index.js
+++ b/imports/ui/Index.js
@@ -3,9 +3,9 @@ import './About.html';
 import './Home.html';
 import './Index.html';
 
-import './HongKongNewGame.js';
-import './JapaneseNewGame.js';
-import './ranking/Ranking.js';
+import './HongKongNewGame';
+import './JapaneseNewGame';
+import './ranking/Ranking';
 
 Template.Index.onCreated( function() {
 	this.currentTab = new ReactiveVar( "Home" );

--- a/imports/ui/JapaneseNewGame.js
+++ b/imports/ui/JapaneseNewGame.js
@@ -1,10 +1,10 @@
 //Databases
-import { Players } from '../api/Players.js';
-import { JapaneseHands } from '../api/GameDatabases.js';
+import Players from '../api/Players';
+import { JapaneseHands } from '../api/GameDatabases';
 
-import { Constants } from '../api/Constants.js';
-import { EloCalculator } from '../api/EloCalculator.js';
-import { NewGameUtils } from '../api/NewGameUtils.js';
+import Constants from '../api/Constants';
+import { EloCalculator } from '../api/EloCalculator';
+import NewGameUtils from '../api/utils/NewGameUtils';
 
 import './JapaneseNewGame.html';
 

--- a/imports/ui/JapaneseNewGame.js
+++ b/imports/ui/JapaneseNewGame.js
@@ -3,7 +3,7 @@ import Players from '../api/Players';
 import { JapaneseHands } from '../api/GameDatabases';
 
 import Constants from '../api/Constants';
-import { EloCalculator } from '../api/EloCalculator';
+import EloCalculator from '../api/EloCalculator';
 import NewGameUtils from '../api/utils/NewGameUtils';
 
 import './JapaneseNewGame.html';

--- a/imports/ui/ranking/HongKongRanking.html
+++ b/imports/ui/ranking/HongKongRanking.html
@@ -1,6 +1,3 @@
 <template name="HongKongRanking">
-	{{ > Ranking 
-		sortBy=(toObj hongKongElo=-1)
-		format=GAME_TYPE.HONG_KONG
-	}}
+	{{ > Ranking getContext }}
 </template>

--- a/imports/ui/ranking/HongKongRanking.js
+++ b/imports/ui/ranking/HongKongRanking.js
@@ -1,0 +1,11 @@
+import Constants from '../../api/Constants';
+import './HongKongRanking.html';
+
+Template.HongKongRanking.helpers({
+    getContext() {
+        return {
+            format: Constants.GAME_TYPE.HONG_KONG,
+            hongKongElo: -1
+        };
+    }
+})

--- a/imports/ui/ranking/HongKongRanking.js
+++ b/imports/ui/ranking/HongKongRanking.js
@@ -5,7 +5,9 @@ Template.HongKongRanking.helpers({
 	getContext() {
 		return {
 			format: Constants.GAME_TYPE.HONG_KONG,
-			hongKongElo: -1
+			sort: {
+				hongKongElo: -1
+			}
 		};
 	}
 })

--- a/imports/ui/ranking/HongKongRanking.js
+++ b/imports/ui/ranking/HongKongRanking.js
@@ -2,10 +2,10 @@ import Constants from '../../api/Constants';
 import './HongKongRanking.html';
 
 Template.HongKongRanking.helpers({
-    getContext() {
-        return {
-            format: Constants.GAME_TYPE.HONG_KONG,
-            hongKongElo: -1
-        };
-    }
+	getContext() {
+		return {
+			format: Constants.GAME_TYPE.HONG_KONG,
+			hongKongElo: -1
+		};
+	}
 })

--- a/imports/ui/ranking/JapaneseRanking.html
+++ b/imports/ui/ranking/JapaneseRanking.html
@@ -1,6 +1,3 @@
 <template name="JapaneseRanking">
-	{{ > Ranking 
-		sortBy=(toObj japaneseElo=-1)
-		format=GAME_TYPE.JAPANESE
-	}}
+	{{ > Ranking getContext }}
 </template>

--- a/imports/ui/ranking/JapaneseRanking.js
+++ b/imports/ui/ranking/JapaneseRanking.js
@@ -5,7 +5,9 @@ Template.JapaneseRanking.helpers({
 	getContext() {
 		return {
 			format: Constants.GAME_TYPE.JAPANESE,
-			japaneseElo: -1
+			sort: {
+				japaneseElo: -1
+			}
 		};
 	}
 });

--- a/imports/ui/ranking/JapaneseRanking.js
+++ b/imports/ui/ranking/JapaneseRanking.js
@@ -2,10 +2,10 @@ import Constants from '../../api/Constants';
 import './JapaneseRanking.html';
 
 Template.JapaneseRanking.helpers({
-    getContext() {
-        return {
-            format: Constants.GAME_TYPE.JAPANESE,
-            japaneseElo: -1
-        };
-    }
+	getContext() {
+		return {
+			format: Constants.GAME_TYPE.JAPANESE,
+			japaneseElo: -1
+		};
+	}
 });

--- a/imports/ui/ranking/JapaneseRanking.js
+++ b/imports/ui/ranking/JapaneseRanking.js
@@ -1,0 +1,11 @@
+import Constants from '../../api/Constants';
+import './JapaneseRanking.html';
+
+Template.JapaneseRanking.helpers({
+    getContext() {
+        return {
+            format: Constants.GAME_TYPE.JAPANESE,
+            japaneseElo: -1
+        };
+    }
+});

--- a/imports/ui/ranking/Ranking.html
+++ b/imports/ui/ranking/Ranking.html
@@ -10,17 +10,14 @@
         </tr>
         <!-- The following lines get the format argument from the templates JapaneseRanking or HongKongRanking -->
         {{ #each player in (getPlayers format sort) }}
-            <!-- Retrieves an info object to display information shown on the ranking list -->
-            {{ #let info=(getInfo format player) }}
-                <tr class="player"
-                    data-player="{{ info.id }}"
-                    data-format="{{ format }}">
-                    <td class="rank">{{ info.rank }}</td>
-                    <td class="players">{{ info.leagueName }}</td>
-                    <td class="elo">{{ info.elo }}</td>
-                    <td class="games-played">{{ info.gamesPlayed }}</td>
-                </tr>
-            {{ /let }}
+            <tr class="player"
+                data-player="{{ player.id }}"
+                data-format="{{ format }}">
+                <td class="rank">{{ player.rank }}</td>
+                <td class="players">{{ player.leagueName }}</td>
+                <td class="elo">{{ player.elo }}</td>
+                <td class="games-played">{{ player.gamesPlayed }}</td>
+            </tr>
         {{ /each }}
     </table>
 </template>

--- a/imports/ui/ranking/Ranking.html
+++ b/imports/ui/ranking/Ranking.html
@@ -1,5 +1,6 @@
 <template name="Ranking">
-    <h2>{{ getName format }}</h2>
+    <h2>{{ getName format }} {{ MAHJONG_CLUB_LEAGUE }}</h2>
+    {{ > PlayerModal }}
     <table class="ranking">
         <tr>
             <th class="rank">#</th>
@@ -8,10 +9,12 @@
             <th class="games-played">Games Played</th>
         </tr>
         <!-- The following lines get the format argument from the templates JapaneseRanking or HongKongRanking -->
-        {{ #each player in (getPlayers sortBy format) }}
+        {{ #each player in (getPlayers format sort) }}
             <!-- Retrieves an info object to display information shown on the ranking list -->
             {{ #let info=(getInfo format player) }}
-                <tr>
+                <tr class="player"
+                    data-player="{{ info.id }}"
+                    data-format="{{ format }}">
                     <td class="rank">{{ info.rank }}</td>
                     <td class="players">{{ info.leagueName }}</td>
                     <td class="elo">{{ info.elo }}</td>

--- a/imports/ui/ranking/Ranking.js
+++ b/imports/ui/ranking/Ranking.js
@@ -26,8 +26,9 @@ Template.Ranking.helpers({
 Template.Ranking.events({
 	'click .player': (event) => {
 		event.preventDefault();
+		let statistics = GameTypeUtils.getPlayer(Template.currentData()['format'], { _id: event.currentTarget.dataset["player"] });
 
-		Session.set("statisticsID", event.currentTarget.dataset["player"]);
+		Session.set("selectedStatistics", statistics);
 		$("#modal").modal('show');
 	}
 });

--- a/imports/ui/ranking/Ranking.js
+++ b/imports/ui/ranking/Ranking.js
@@ -6,20 +6,16 @@ import './JapaneseRanking';
 import './Ranking.html';
 
 Template.Ranking.helpers({
-	getInfo(format, player) {
-		player["elo"] = player["elo"].toFixed(3);
-		return {
-			...player,
-			rank: this.rank ? ++this.rank : this.rank = 1
-		};
-	},
-
 	getName(format) {
 		return GameTypeUtils.formatName(format);
 	},
 
 	getPlayers(format, sort) {
-		return GameTypeUtils.getPlayers(format, sort);
+		return GameTypeUtils.getPlayers(format, sort).map((p, i) => ({
+			...p,
+			elo: p.elo.toFixed(3),
+			rank: i + 1
+		}));
 	}
 });
 

--- a/imports/ui/ranking/Ranking.js
+++ b/imports/ui/ranking/Ranking.js
@@ -1,72 +1,33 @@
-import { Players } from '../../api/Players.js';
-import { Constants } from '../../api/Constants.js';
+import GameTypeUtils from '../../api/utils/GameTypeUtils';
 
-import './HongKongRanking.html';
-import './JapaneseRanking.html';
+import '../statistics/PlayerModal';
+import './HongKongRanking';
+import './JapaneseRanking';
 import './Ranking.html';
-
-Template.registerHelper('toObj', (args) => {
-		return args.hash;
-});
 
 Template.Ranking.helpers({
 	getInfo(format, player) {
-		let leagueName;
-		let elo;
-		let gamesPlayed;
-		switch (format) {
-		case Constants.GAME_TYPE.JAPANESE:
-			leagueName = player.japaneseLeagueName;
-			elo = player.japaneseElo;
-			gamesPlayed = player.japaneseGamesPlayed;
-			break;
-		case Constants.GAME_TYPE.HONG_KONG:
-			leagueName = player.hongKongLeagueName;
-			elo = player.hongKongElo;
-			gamesPlayed = player.hongKongGamesPlayed;
-			break;
-		default:
-			console.error("Format '" + format + "' is invalid");
-			break;
-		}
-
+		player["elo"] = player["elo"].toFixed(3);
 		return {
-			"leagueName": leagueName,
-			"elo": elo.toFixed(3),
-			"rank": this.rank ? ++this.rank : this.rank = 1,
-			"gamesPlayed": gamesPlayed
+			...player,
+			rank: this.rank ? ++this.rank : this.rank = 1
 		};
 	},
+
 	getName(format) {
-		let league;
-		switch (format) {
-		case Constants.GAME_TYPE.JAPANESE:
-			league = "Japanese";
-			break;
-		case Constants.GAME_TYPE.HONG_KONG:
-			league = "Hong Kong";
-			break;
-		default:
-			console.error("Format '" + format + "' is invalid");
-			break;
-		}
-
-		return league + " " + Constants.MAHJONG_CLUB_LEAGUE;
+		return GameTypeUtils.formatName(format);
 	},
-	getPlayers(sortBy, format) {
-		let hasPlayedGame = {};
-		switch (format) {
-		case Constants.GAME_TYPE.JAPANESE:
-			hasPlayedGame["japaneseGamesPlayed"] = { $gt: 0 };
-			break;
-		case Constants.GAME_TYPE.HONG_KONG:
-			hasPlayedGame["hongKongGamesPlayed"] = { $gt: 0 };
-			break;
-		default:
-			console.error("Format '" + format + "' is invalid");
-			break;
-		}
 
-		return Players.find(hasPlayedGame, { "sort": sortBy });
+	getPlayers(format, sort) {
+		return GameTypeUtils.getPlayers(format, sort);
+	}
+});
+
+Template.Ranking.events({
+	'click .player': (event) => {
+		event.preventDefault();
+
+		Session.set("statisticsID", event.currentTarget.dataset["player"]);
+		$("#modal").modal('show');
 	}
 });

--- a/imports/ui/statistics/PlayerModal.html
+++ b/imports/ui/statistics/PlayerModal.html
@@ -1,0 +1,38 @@
+<template name="PlayerModal">
+    <div class="modal fade" id="modal" tabindex="-1" role="dialog">
+        <div class="modal-dialog" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                    <h3 class="modal-title">Player Statistics</h3>
+                </div>
+                <div class="modal-body">
+                    <h4 class="statistics-title">{{ player.name }} - Rank {{ player.rank }}</h4>
+                    <table class="table">
+                        <tbody>
+                            <tr>
+                                <td>Win rate: {{ player.winRate }}</td>
+                                <td>Deal-in rate: {{ player.dealin }}</td>
+                            </tr>
+                            <tr>
+                                <td>Average position: {{ player.averagePosition }}</td>
+                                <td>Average hand size: {{ player.averageHandSize }}</td>
+                            </tr>
+                            <tr>
+                                <td>Fly rate: {{ player.flyRate }}</td>
+                                <td>Chombos: {{ player.chombo }}</td>
+                            </tr>
+                            <tr>
+                                <td>Riichi rate: {{ player.riichis }}</td>
+                                <td>Riichi win rate: {{ player.riichiWinRate }}</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                </div>
+            </div>
+        </div>
+    </div>
+</template>

--- a/imports/ui/statistics/PlayerModal.html
+++ b/imports/ui/statistics/PlayerModal.html
@@ -4,30 +4,34 @@
             <div class="modal-content">
                 <div class="modal-header">
                     <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                    <h3 class="modal-title">Player Statistics</h3>
+                    <h2 class="modal-title">Player Statistics</h2>
                 </div>
                 <div class="modal-body">
-                    <h4 class="statistics-title">{{ player.name }} - Rank {{ player.rank }}</h4>
-                    <table class="table">
-                        <tbody>
-                            <tr>
-                                <td>Win rate: {{ player.winRate }}</td>
-                                <td>Deal-in rate: {{ player.dealin }}</td>
-                            </tr>
-                            <tr>
-                                <td>Average position: {{ player.averagePosition }}</td>
-                                <td>Average hand size: {{ player.averageHandSize }}</td>
-                            </tr>
-                            <tr>
-                                <td>Fly rate: {{ player.flyRate }}</td>
-                                <td>Chombos: {{ player.chombo }}</td>
-                            </tr>
-                            <tr>
-                                <td>Riichi rate: {{ player.riichis }}</td>
-                                <td>Riichi win rate: {{ player.riichiWinRate }}</td>
-                            </tr>
-                        </tbody>
-                    </table>
+                    {{ #let player=getPlayerInfo }}
+                        <h3 class="statistics-title">{{ player.name }}</h3>
+                        <table class="table">
+                            <tbody>
+                                <tr>
+                                    <td>Win rate: {{ player.winRate }}%</td>
+                                    <td>Deal-in rate: {{ player.dealin }}%</td>
+                                </tr>
+                                <tr>
+                                    <td>Average position: {{ player.averagePosition }}</td>
+                                    <td>Average hand size: {{ player.averageHandSize }}</td>
+                                </tr>
+                                <tr>
+                                    <td>Fly rate: {{ player.flyRate }}%</td>
+                                    <td>Chombos: {{ player.chombo }}</td>
+                                </tr>
+                                {{ #if player.riichis }}
+                                    <tr>
+                                        <td>Riichi rate: {{ player.riichis }}%</td>
+                                        <td>Riichi win rate: {{ player.riichiWinRate }}%</td>
+                                    </tr>
+                                {{ /if }}
+                            </tbody>
+                        </table>
+                    {{ /let }}
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>

--- a/imports/ui/statistics/PlayerModal.html
+++ b/imports/ui/statistics/PlayerModal.html
@@ -12,7 +12,7 @@
                         <table class="table">
                             <tbody>
                                 <tr>
-                                    <td>Win rate: {{ player.winRate }}%</td>
+                                    <td>Hand win rate: {{ player.winRate }}%</td>
                                     <td>Deal-in rate: {{ player.dealin }}%</td>
                                 </tr>
                                 <tr>

--- a/imports/ui/statistics/PlayerModal.html
+++ b/imports/ui/statistics/PlayerModal.html
@@ -1,42 +1,42 @@
 <template name="PlayerModal">
-    <div class="modal fade" id="modal" tabindex="-1" role="dialog">
-        <div class="modal-dialog" role="document">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                    <h2 class="modal-title">Player Statistics</h2>
-                </div>
-                <div class="modal-body">
-                    {{ #let player=getPlayerInfo }}
-                        <h3 class="statistics-title">{{ player.name }}</h3>
-                        <table class="table">
-                            <tbody>
-                                <tr>
-                                    <td>Hand win rate: {{ player.winRate }}%</td>
-                                    <td>Deal-in rate: {{ player.dealin }}%</td>
-                                </tr>
-                                <tr>
-                                    <td>Average position: {{ player.averagePosition }}</td>
-                                    <td>Average hand size: {{ player.averageHandSize }}</td>
-                                </tr>
-                                <tr>
-                                    <td>Fly rate: {{ player.flyRate }}%</td>
-                                    <td>Chombos: {{ player.chombo }}</td>
-                                </tr>
-                                {{ #if player.riichis }}
-                                    <tr>
-                                        <td>Riichi rate: {{ player.riichis }}%</td>
-                                        <td>Riichi win rate: {{ player.riichiWinRate }}%</td>
-                                    </tr>
-                                {{ /if }}
-                            </tbody>
-                        </table>
-                    {{ /let }}
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-                </div>
-            </div>
-        </div>
-    </div>
+	<div class="modal fade" id="modal" tabindex="-1" role="dialog">
+		<div class="modal-dialog" role="document">
+			<div class="modal-content">
+				<div class="modal-header">
+					<button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+					<h2 class="modal-title">Player Statistics</h2>
+				</div>
+				<div class="modal-body">
+					{{ #let player=getPlayerInfo }}
+						<h3 class="statistics-title">{{ player.name }}</h3>
+						<table class="table">
+							<tbody>
+								<tr>
+									<td>Hand win rate: {{ player.winRate }}%</td>
+									<td>Deal-in rate: {{ player.dealin }}%</td>
+								</tr>
+								<tr>
+									<td>Average position: {{ player.averagePosition }}</td>
+									<td>Average hand size: {{ player.averageHandSize }}</td>
+								</tr>
+								<tr>
+									<td>Fly rate: {{ player.flyRate }}%</td>
+									<td>Chombos: {{ player.chombo }}</td>
+								</tr>
+								{{ #if player.riichis }}
+									<tr>
+										<td>Riichi rate: {{ player.riichis }}%</td>
+										<td>Riichi win rate: {{ player.riichiWinRate }}%</td>
+									</tr>
+								{{ /if }}
+							</tbody>
+						</table>
+					{{ /let }}
+				</div>
+				<div class="modal-footer">
+					<button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+				</div>
+			</div>
+		</div>
+	</div>
 </template>

--- a/imports/ui/statistics/PlayerModal.js
+++ b/imports/ui/statistics/PlayerModal.js
@@ -10,16 +10,16 @@ Template.PlayerModal.helpers({
 			let info = {};
 			info.name = player.leagueName;
 			info.elo = player.elo.toFixed(3);
-			info.winRate = (player.handsWin / player.handsTotal * 100).toFixed(1);
-			info.dealin = (player.handsLose / player.handsTotal * 100).toFixed(1);
-			info.averagePosition = ((player.firstPlaceSum + 2 * player.secondPlaceSum + 3 * player.thirdPlaceSum + 4 * player.fourthPlaceSum) / player.gamesPlayed).toFixed(1);
-			info.averageHandSize = player.handsWin ? (player.winPointsTotal / player.handsWin).toFixed(1) : 0;
-			info.flyRate = (player.bankruptTotal / player.gamesPlayed * 100).toFixed(1);
+			info.winRate = (player.handsWin / player.handsTotal * 100).toFixed(2);
+			info.dealin = (player.handsLose / player.handsTotal * 100).toFixed(2);
+			info.averagePosition = ((player.firstPlaceSum + 2 * player.secondPlaceSum + 3 * player.thirdPlaceSum + 4 * player.fourthPlaceSum) / player.gamesPlayed).toFixed(2);
+			info.averageHandSize = player.handsWin ? (player.winPointsTotal / player.handsWin).toFixed(2) : 0;
+			info.flyRate = (player.bankruptTotal / player.gamesPlayed * 100).toFixed(2);
 			info.chombo = player.chomboTotal;
 
 			if (player.riichiTotal !== undefined && player.winRiichiTotal !== undefined) {
-				info.riichis = (player.riichiTotal / player.handsTotal * 100).toFixed(1);
-				info.riichiWinRate = (player.riichiTotal ? (player.winRiichiTotal / player.riichiTotal * 100) : 0).toFixed(1);
+				info.riichis = (player.riichiTotal / player.handsTotal * 100).toFixed(2);
+				info.riichiWinRate = (player.riichiTotal ? (player.winRiichiTotal / player.riichiTotal * 100) : 0).toFixed(2);
 			}
 
 			return info;

--- a/imports/ui/statistics/PlayerModal.js
+++ b/imports/ui/statistics/PlayerModal.js
@@ -3,4 +3,26 @@ import Constants from '../../api/Constants';
 
 import './PlayerModal.html';
 
-Template.PlayerModal.helpers({});
+Template.PlayerModal.helpers({
+    getPlayerInfo() {
+        let player = Session.get("selectedStatistics");
+        if (player) {
+            let info = {};
+            info.name = player.leagueName;
+            info.elo = player.elo.toFixed(3);
+            info.winRate = (player.handsWin / player.handsTotal * 100).toFixed(1);
+            info.dealin = (player.handsLose / player.handsTotal * 100).toFixed(1);
+            info.averagePosition = ((player.firstPlaceSum + 2 * player.secondPlaceSum + 3 * player.thirdPlaceSum + 4 * player.fourthPlaceSum) / player.gamesPlayed).toFixed(1);
+            info.averageHandSize = player.handsWin ? (player.winPointsTotal / player.handsWin).toFixed(1) : 0;
+            info.flyRate = (player.bankruptTotal / player.gamesPlayed * 100).toFixed(1);
+            info.chombo = player.chomboTotal;
+
+            if (player.riichiTotal !== undefined && player.winRiichiTotal !== undefined) {
+                info.riichis = (player.riichiTotal / player.handsTotal * 100).toFixed(1);
+                info.riichiWinRate = (player.winRiichiTotal / player.riichiTotal * 100).toFixed(1);
+            }
+
+            return info;
+        }
+    }
+});

--- a/imports/ui/statistics/PlayerModal.js
+++ b/imports/ui/statistics/PlayerModal.js
@@ -1,0 +1,6 @@
+import Players from '../../api/Players';
+import Constants from '../../api/Constants';
+
+import './PlayerModal.html';
+
+Template.PlayerModal.helpers({});

--- a/imports/ui/statistics/PlayerModal.js
+++ b/imports/ui/statistics/PlayerModal.js
@@ -19,7 +19,7 @@ Template.PlayerModal.helpers({
 
             if (player.riichiTotal !== undefined && player.winRiichiTotal !== undefined) {
                 info.riichis = (player.riichiTotal / player.handsTotal * 100).toFixed(1);
-                info.riichiWinRate = (player.winRiichiTotal / player.riichiTotal * 100).toFixed(1);
+                info.riichiWinRate = (player.riichiTotal ? (player.winRiichiTotal / player.riichiTotal * 100) : 0).toFixed(1);
             }
 
             return info;

--- a/imports/ui/statistics/PlayerModal.js
+++ b/imports/ui/statistics/PlayerModal.js
@@ -4,25 +4,25 @@ import Constants from '../../api/Constants';
 import './PlayerModal.html';
 
 Template.PlayerModal.helpers({
-    getPlayerInfo() {
-        let player = Session.get("selectedStatistics");
-        if (player) {
-            let info = {};
-            info.name = player.leagueName;
-            info.elo = player.elo.toFixed(3);
-            info.winRate = (player.handsWin / player.handsTotal * 100).toFixed(1);
-            info.dealin = (player.handsLose / player.handsTotal * 100).toFixed(1);
-            info.averagePosition = ((player.firstPlaceSum + 2 * player.secondPlaceSum + 3 * player.thirdPlaceSum + 4 * player.fourthPlaceSum) / player.gamesPlayed).toFixed(1);
-            info.averageHandSize = player.handsWin ? (player.winPointsTotal / player.handsWin).toFixed(1) : 0;
-            info.flyRate = (player.bankruptTotal / player.gamesPlayed * 100).toFixed(1);
-            info.chombo = player.chomboTotal;
+	getPlayerInfo() {
+		let player = Session.get("selectedStatistics");
+		if (player) {
+			let info = {};
+			info.name = player.leagueName;
+			info.elo = player.elo.toFixed(3);
+			info.winRate = (player.handsWin / player.handsTotal * 100).toFixed(1);
+			info.dealin = (player.handsLose / player.handsTotal * 100).toFixed(1);
+			info.averagePosition = ((player.firstPlaceSum + 2 * player.secondPlaceSum + 3 * player.thirdPlaceSum + 4 * player.fourthPlaceSum) / player.gamesPlayed).toFixed(1);
+			info.averageHandSize = player.handsWin ? (player.winPointsTotal / player.handsWin).toFixed(1) : 0;
+			info.flyRate = (player.bankruptTotal / player.gamesPlayed * 100).toFixed(1);
+			info.chombo = player.chomboTotal;
 
-            if (player.riichiTotal !== undefined && player.winRiichiTotal !== undefined) {
-                info.riichis = (player.riichiTotal / player.handsTotal * 100).toFixed(1);
-                info.riichiWinRate = (player.riichiTotal ? (player.winRiichiTotal / player.riichiTotal * 100) : 0).toFixed(1);
-            }
+			if (player.riichiTotal !== undefined && player.winRiichiTotal !== undefined) {
+				info.riichis = (player.riichiTotal / player.handsTotal * 100).toFixed(1);
+				info.riichiWinRate = (player.riichiTotal ? (player.winRiichiTotal / player.riichiTotal * 100) : 0).toFixed(1);
+			}
 
-            return info;
-        }
-    }
+			return info;
+		}
+	}
 });

--- a/server/main.js
+++ b/server/main.js
@@ -1,7 +1,6 @@
 import { Meteor } from 'meteor/meteor';
 
 import Players from '../imports/api/Players';
-import { HongKongHands } from '../imports/api/GameDatabases'
 
 Meteor.startup(() => {
 	// code to run on server at startup

--- a/server/main.js
+++ b/server/main.js
@@ -4,46 +4,45 @@ import Players from '../imports/api/Players';
 import { HongKongHands } from '../imports/api/GameDatabases'
 
 Meteor.startup(() => {
-  // code to run on server at startup
+	// code to run on server at startup
+	// Temporary template player for first run
+	// You can use this to edit in the database
+	if (Players.find().count() === 0) {
+		for (let i = 0; i < 4; i++) {
+		Players.insert({
+			name: "DELETE_ME_" + i,
 
-  // Temporary template player for first run
-  // You can use this to edit in the database
-  if (Players.find().count() === 0) {
-		Players.insert(
-  		{
-  			name: "DELETE_ME",
-  			hongKongLeagueName: "HK_DELETE_ME",
-  			hongKongElo: 0, //added
-  			hongKongGamesPlayed: 0, //added
-  			hongKongPositionSum: 0, //added
-  			hongKongHandsWin: 0, //added
-  			hongKongHandsLose: 0, //added
-  			hongKongHandsTotal: 0, //added
-  			hongKongWinPointsTotal: 0, //added
-  			hongKongChomboTotal: 0, //added
-  			hongKongBankruptTotal: 0, //added
+			hongKongLeagueName: "HK_DELETE_ME_" + i,
+			hongKongElo: 0, //added
+			hongKongGamesPlayed: 0, //added
+			hongKongHandsWin: 0, //added
+			hongKongHandsLose: 0, //added
+			hongKongHandsTotal: 0, //added
+			hongKongWinPointsTotal: 0, //added
+			hongKongChomboTotal: 0, //added
+			hongKongBankruptTotal: 0, //added
 			hongKongFirstPlaceSum: 0, //added
 			hongKongSecondPlaceSum: 0, //added
 			hongKongThirdPlaceSum: 0, //added
 			hongKongFourthPlaceSum: 0, //added
 
-  			japaneseLeagueName: "JPN_DELETE_ME",
-  			japaneseElo: 0, //added
-  			japaneseGamesPlayed: 0, //added
-  			japanesePositionSum: 0, //added
-  			japaneseHandsWin: 0, //added
-  			japaneseHandsLose: 0, //added
-  			japaneseHandsTotal: 0, //added
-  			japaneseWinPointsTotal: 0, //added
-  			japaneseWinDoraTotal: 0, //added
-  			japaneseRiichiTotal: 0, //added
-  			japaneseWinRiichiTotal: 0, //added
-  			japaneseChomboTotal: 0, //added
-  			japaneseBankruptTotal: 0, //added
+			japaneseLeagueName: "JPN_DELETE_ME_" + i,
+			japaneseElo: 0, //added
+			japaneseGamesPlayed: 0, //added
+			japaneseHandsWin: 0, //added
+			japaneseHandsLose: 0, //added
+			japaneseHandsTotal: 0, //added
+			japaneseWinPointsTotal: 0, //added
+			japaneseWinDoraTotal: 0, //added
+			japaneseRiichiTotal: 0, //added
+			japaneseWinRiichiTotal: 0, //added
+			japaneseChomboTotal: 0, //added
+			japaneseBankruptTotal: 0, //added
 			japaneseFirstPlaceSum: 0, //added
 			japaneseSecondPlaceSum: 0, //added
 			japaneseThirdPlaceSum: 0, //added
 			japaneseFourthPlaceSum: 0, //added
-  		});
+			});
+		}
 	}
 });

--- a/server/main.js
+++ b/server/main.js
@@ -2,6 +2,10 @@ import { Meteor } from 'meteor/meteor';
 
 import Players from '../imports/api/Players';
 
+// We need to instantiate the collections server-side. Maintain this import, even though
+// we don't use it at all
+import '../imports/api/GameDatabases';
+
 Meteor.startup(() => {
 	// code to run on server at startup
 	// Temporary template player for first run

--- a/server/main.js
+++ b/server/main.js
@@ -1,7 +1,7 @@
 import { Meteor } from 'meteor/meteor';
 
-import { Players } from '../imports/api/Players.js';
-import { HongKongHands } from '../imports/api/GameDatabases.js'
+import Players from '../imports/api/Players';
+import { HongKongHands } from '../imports/api/GameDatabases'
 
 Meteor.startup(() => {
   // code to run on server at startup


### PR DESCRIPTION
# Details
In this commit, I've moved code that evaluates game type formats into its custom util class, to clean up the Ranking template a little. Furthermore, I expanded on the ranking template to open up a modal containing relevant information for Japanese/Hong Kong game types.

# Changes
- Moved `NewGameUtils` to `imports/api/utils`
- Added `GameTypeUtils` to `imports/api/utils`
    - `GameTypeUtils` converts constants such as `jpn` and `hkg` to user-friendly strings
    - `GameTypeUtils` creates a consistent API for referencing player attributes for `Rankings`
- Removed `.js` tags in imports; These are unnecessary as Meteor does an automatic lookup with this suffix
- Converted `Constants`, `Players`, and `NewGameUtils` to default exports. This means that `{ Constants }` is no longer necessary. We can directly import via `import Constants from ...`
- Removed the `toObj` global helper. Work for determining what formats to use and how to sort each rankings page are done on a template-level now
- Added the `PlayerModal`
- `PlayerModal` can be accessed by clicking/tapping a name on the rankings page
    - `PlayerModal` will show the following statistics
        - win %
        - lose %
        - average position
        - average hand size
        - fly %
        - chombos
        - (Japanese) riichi %
        - (Japanese) riichi win %
