### PR TITLE
Make drop-down logic simpler and more specific

### DIFF
--- a/imports/ui/Index.html
+++ b/imports/ui/Index.html
@@ -5,7 +5,7 @@
 			<a data-toggle="tab" href="#">Home</a>
 		</li>
 
-		<li data-template="null" class="dropdown">
+		<li class="dropdown">
 			<a class="dropdown-toggle" data-toggle="dropdown" href="#">League Ranking<span class="caret"></span></a>
 			<u1 class="dropdown-menu">
 				<li data-template="HongKongRanking" role="presentation">
@@ -17,7 +17,7 @@
 			</u1>
 		</li>
 
-		<li data-template="null" class="dropdown">
+		<li class="dropdown">
 			<a class="dropdown-toggle" data-toggle="dropdown" href="#">New Game
 			<span class="caret"></span></a>
 			<u1 class="dropdown-menu">

--- a/imports/ui/Index.js
+++ b/imports/ui/Index.js
@@ -18,11 +18,12 @@ Template.Index.helpers({
 
 Template.Index.events({
 	'click .nav-tabs li'( event, template ) {
-		// Prevent dropdown menus from being selectable, but maintain their clickiness
-		if ($( event.target ).attr( 'class' ) == "dropdown-toggle" )
-			return;
-
+		// Prevent dropdown menus from being selectable,
+		// but maintain their clickiness
 		var currentTab = $( event.target ).closest( "li" );
+
+		if (currentTab.data("template") === null)
+			return;
 
 		currentTab.addClass( "active" );
 		$( ".nav-tabs li" ).not( currentTab ).removeClass( "active" );

--- a/imports/ui/Index.js
+++ b/imports/ui/Index.js
@@ -22,7 +22,7 @@ Template.Index.events({
 		// but maintain their clickiness
 		var currentTab = $( event.target ).closest( "li" );
 
-		if (currentTab.data("template") === null)
+		if (currentTab.data("template") === undefined)
 			return;
 
 		currentTab.addClass( "active" );


### PR DESCRIPTION
Instead of checking to see if user clicked a dropdown-menu, check to see if clicked item has any data to load.

#59 